### PR TITLE
build: atualiza versão para 1.7.5 e pacotes NuGet

### DIFF
--- a/src/OpenAC.Net.NFSe.DANFSe.FastReport.OpenSource/OpenAC.Net.NFSe.DANFSe.FastReport.OpenSource.csproj
+++ b/src/OpenAC.Net.NFSe.DANFSe.FastReport.OpenSource/OpenAC.Net.NFSe.DANFSe.FastReport.OpenSource.csproj
@@ -21,9 +21,9 @@
     <NeutralLanguage>pt-BR</NeutralLanguage>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <AssemblyVersion>1.7.3</AssemblyVersion>
-    <FileVersion>1.7.3</FileVersion>
-    <Version>1.7.4</Version>
+    <AssemblyVersion>1.7.5</AssemblyVersion>
+    <FileVersion>1.7.5</FileVersion>
+    <Version>1.7.5</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <DebugType>embedded</DebugType>
@@ -43,8 +43,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FastReport.OpenSource" Version="2026.2.1" />
-    <PackageReference Include="FastReport.OpenSource.Export.PdfSimple" Version="2026.2.1" />
+    <PackageReference Include="FastReport.OpenSource" Version="2026.2.3" />
+    <PackageReference Include="FastReport.OpenSource.Export.PdfSimple" Version="2026.2.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -79,11 +79,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-windows'">
-    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenAC.Net.NFSe.DANFSe.QuestPdf/OpenAC.Net.NFSe.DANFSe.QuestPdf.csproj
+++ b/src/OpenAC.Net.NFSe.DANFSe.QuestPdf/OpenAC.Net.NFSe.DANFSe.QuestPdf.csproj
@@ -20,9 +20,9 @@
         <NeutralLanguage>pt-BR</NeutralLanguage>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <AssemblyVersion>1.7.3</AssemblyVersion>
-        <FileVersion>1.7.3</FileVersion>
-        <Version>1.7.4</Version>
+        <AssemblyVersion>1.7.5</AssemblyVersion>
+        <FileVersion>1.7.5</FileVersion>
+        <Version>1.7.5</Version>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <DebugType>embedded</DebugType>
@@ -58,7 +58,7 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="QuestPDF" Version="2026.5.0" />
+      <PackageReference Include="QuestPDF" Version="2026.6.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/OpenAC.Net.NFSe.Demo/OpenAC.Net.NFSe.Demo.csproj
+++ b/src/OpenAC.Net.NFSe.Demo/OpenAC.Net.NFSe.Demo.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="NLog.Windows.Forms" Version="6.1.1" />
     <PackageReference Include="OpenAC.Net.Core" Version="1.6.0" />
     <PackageReference Include="OpenAC.Net.DFe.Core" Version="1.6.0.2" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.8" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.9" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/OpenAC.Net.NFSe.Test/OpenAC.Net.NFSe.Test.csproj
+++ b/src/OpenAC.Net.NFSe.Test/OpenAC.Net.NFSe.Test.csproj
@@ -16,7 +16,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="10.0.0">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/OpenAC.Net.NFSe/OpenAC.Net.NFSe.csproj
+++ b/src/OpenAC.Net.NFSe/OpenAC.Net.NFSe.csproj
@@ -20,9 +20,9 @@
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<NeutralLanguage>pt-BR</NeutralLanguage>
-		<AssemblyVersion>1.7.3</AssemblyVersion>
-		<FileVersion>1.7.3</FileVersion>
-		<Version>1.7.4</Version>
+		<AssemblyVersion>1.7.5</AssemblyVersion>
+		<FileVersion>1.7.5</FileVersion>
+		<Version>1.7.5</Version>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<DebugType>embedded</DebugType>
@@ -401,25 +401,25 @@
 	</ItemGroup>
 	
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-	  <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
+	  <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
 	  <PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
 	  <PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 	</ItemGroup>
 	
 	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-	  <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
+	  <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
 	  <PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
 	  <PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 	</ItemGroup>
 	
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-	  <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
+	  <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
 	  <PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
 	  <PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 	</ItemGroup>
 	
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-	  <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
+	  <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
 	  <PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
 	  <PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 	</ItemGroup>

--- a/src/OpenAC.Net.NFSe/Providers/NFeCidades/ProviderNFeCidades.cs
+++ b/src/OpenAC.Net.NFSe/Providers/NFeCidades/ProviderNFeCidades.cs
@@ -39,6 +39,7 @@ using OpenAC.Net.NFSe.Nota;
 using System;
 using System.Text;
 using System.Xml.Linq;
+using OpenAC.Net.DFe.Core;
 
 namespace OpenAC.Net.NFSe.Providers;
 


### PR DESCRIPTION
- Atualiza AssemblyVersion, FileVersion e Version para 1.7.5 nos projetos principais.
- Atualiza dependência System.Drawing.Common para versão 10.0.9.
- Atualiza dependência System.Text.Encoding.CodePages para versão 10.0.9.
- Atualiza dependências FastReport.OpenSource e FastReport.OpenSource.Export.PdfSimple para versão 2026.2.3.
- Atualiza dependência QuestPDF para versão 2026.6.0.
- Atualiza dependência coverlet.collector para versão 10.0.1.
- Adiciona importação do namespace OpenAC.Net.DFe.Core em ProviderNFeCidades.